### PR TITLE
[codex] remove extra UI hints

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -423,7 +423,6 @@ function updateThemeToggle(theme) {
 
     themeToggle.dataset.themeMode = theme;
     themeToggle.setAttribute("aria-label", `Switch theme to ${nextLabel}`);
-    themeToggle.setAttribute("title", `Switch theme to ${nextLabel}`);
 }
 
 function syncTheme(theme = getStoredTheme(), systemPrefersDark = colorSchemeMediaQuery.matches) {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -32,7 +32,6 @@ const { showDivider = false } = Astro.props;
                             type="button"
                             data-theme-mode="system"
                             aria-label="Switch theme to Light"
-                            title="Switch theme to Light"
                             class="header-action group size-6 flex items-center justify-center rounded-full"
                         >
                             <svg
@@ -96,7 +95,6 @@ const { showDivider = false } = Astro.props;
                             type="button"
                             data-search-trigger="true"
                             aria-label="Search articles"
-                            title="Search articles"
                             aria-haspopup="dialog"
                             aria-controls="site-search"
                             class="header-action group size-6 flex items-center justify-center rounded-full"

--- a/src/components/LinkCard.astro
+++ b/src/components/LinkCard.astro
@@ -18,12 +18,6 @@ function getHostLabel(url: string): string {
 
 const meta = item.platform ?? getHostLabel(item.url).toLowerCase();
 const placeholder = item.title.trim().slice(0, 1).toUpperCase();
-const statusLabel =
-    item.status === "up"
-        ? "Site reachable"
-        : item.status === "limited"
-          ? "Site reachable with request limits"
-          : "Site unreachable";
 ---
 
 <li class="group h-full" data-link-card="true">
@@ -33,19 +27,6 @@ const statusLabel =
         rel="noopener noreferrer"
         class="relative flex h-full min-h-14 items-center gap-2.5 rounded-lg border border-black/12 bg-white/35 px-2.5 py-2.5 transition-colors duration-300 hover:border-black/18 hover:bg-white/55 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/10 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-100 dark:border-white/7 dark:bg-white/[0.025] dark:hover:border-white/12 dark:hover:bg-white/[0.045] dark:focus-visible:ring-white/16 dark:focus-visible:ring-offset-stone-900"
     >
-        {item.status && (
-      <span
-        class:list={[
-          "absolute top-2 right-2 size-1.5 rounded-full",
-          item.status === "down" ? "bg-rose-500" : "bg-emerald-500",
-        ]}
-        data-link-status={item.status}
-        role="img"
-        aria-label={statusLabel}
-        title={statusLabel}
-      />
-    )}
-
         <div
             class="flex size-6 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-transparent"
         >

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -44,7 +44,6 @@ const blog = (await getCollection("blog"))
               rel="noopener noreferrer"
               class="hover:text-[#292827] dark:hover:text-[#d8d3ca] transition-colors duration-300"
               aria-label={social.NAME}
-              title={social.NAME}
             >
               <Image
                 src={social.ICON}


### PR DESCRIPTION
## Intent
Remove extra UI hints that surfaced as native hover tooltips or link-card status indicators.

## Implementation
- Removed `title` attributes from header icon buttons and home social links while keeping accessible labels.
- Stopped dynamically writing a `title` attribute for the theme toggle.
- Removed the link-card reachability status dot and its tooltip/status label from the rendered card UI.

## Validation
- `pnpm run check`
- `pnpm run build:site`
- `pnpm run smoke`

## Notes
- Existing dirty changes in `public/assets/images/site/home-hero-*.svg` were left untouched and are not part of this PR.
- `gh auth status` reports an invalid GitHub CLI token, so this PR was opened through the GitHub connector.